### PR TITLE
Offline nodes in grey instead of red

### DIFF
--- a/geomap.js
+++ b/geomap.js
@@ -81,7 +81,7 @@ function update(data) {
   new_nodes.append("circle")
            .attr("r", "4pt")
            .attr("fill", function (d) {
-             return d.flags.online?"rgba(0, 255, 0, 0.8)":"rgba(255, 128, 128, 0.5)"
+             return d.flags.online?"rgba(0, 255, 0, 0.8)":"rgba(128, 128, 128, 0.5)"
            })
            .attr("stroke-width", "0.5px")
            .attr("stroke", "#444")


### PR DESCRIPTION
the color red is already used for weak links between nodes, which doesent mean "offline" there. green is "online" and "strong link", which fits together
