### PR TITLE
Change target to new window for 'Geodaten'

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -283,6 +283,7 @@ function show_node_info(d) {
 
     nodeinfo.append("p")
             .append("a")
+            .attr("target","_blank")
             .attr("href","geomap.html?lat="+d.geo[0]+"&lon="+d.geo[1])
             .text(d.geo)
   }


### PR DESCRIPTION
Open 'Geodaten' link in a new window/tab instead, keeping the loaded graph intact.
