### PR TITLE
enhance linking between graph and geomap

### DIFF
--- a/lib/geomap.js
+++ b/lib/geomap.js
@@ -89,8 +89,8 @@ function update(data) {
            .attr("fill", function (d) {
              return d.flags.online?"rgba(0, 255, 0, 0.8)":"rgba(128, 128, 128, 0.5)"
            })
-          .on("click", function(n) { window.location.href = "graph.html#" + n.id })
-    	  .append("title").text( function (n) { return n.name?n.name:n.id })
+           .on("click", function(n) { window.location.href = "graph.html#" + n.id })
+           .append("title").text( function (n) { return n.name?n.name:n.id })
 
   links_svg.enter().append("line")
             .attr("class", "link")

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -97,7 +97,8 @@ btns.append("button")
 cp.append("input")
   .on("keyup", function(){show_node(this.value)})
   .on("change", function(){show_node(this.value)})
-    
+  .attr("value", window.location.hash.substring(1))
+
 var updated_at = cp.append("p")
 
 var meshinfo = d3.select("#sidebar .content")
@@ -167,6 +168,8 @@ meshinfo.append("input").attr("type", "range").attr("min", "0").attr("max", "2.0
         })
 
 function show_node(query) {
+  window.location.hash = '#' + query
+
   if (query.length == 0) {
     vis.selectAll(".node").classed("marked", false)
     return
@@ -700,6 +703,9 @@ function update() {
 
     force.on("tick", tick_event)
     force.start()
+
+    if (window.location.hash.length > 1)
+      show_node(window.location.hash.substring(1))
   }
 
   initial = 0


### PR DESCRIPTION
This adds a link to the graph in geomap on each node with that node focussed already when the graph is opened.
And it auto updates the hash in the url of the graph, whenever anything is changed in the searchbox in the graph, so the focussed node keeps focussed on a refresh of the site.

This was originally invented by wklabe: https://github.com/toppoint/ffmap-d3/commit/d1df5f8e34b5aae6ad9d4bc4fc6bad632570c865
