### PR TITLE
Adopt backend changes.

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -93,7 +93,7 @@ btns.append("button")
     .attr("value", "labels")
     .text("Labels")
     .on("click", update_graph)
-    
+
 cp.append("input")
   .on("keyup", function(){show_node(this.value)})
   .on("change", function(){show_node(this.value)})
@@ -385,6 +385,9 @@ function reload() {
     var nNodes = data.nodes.filter(function(d) {
                    return !d.flags.client && d.flags.online
                  }).length,
+        nLegacyNodes = data.nodes.filter(function (d) {
+                   return !d.flags.client && d.flags.online && d.flags.legacy
+                 }).length,
         nGateways = data.nodes.filter(function(d) {
                    return d.flags.gateway && d.flags.online
                  }).length,
@@ -399,7 +402,7 @@ function reload() {
       .text(nGateways + " Gateways")
 
     d3.select("#clientcount")
-      .text("ungefähr " + (nClients - nNodes) + " Clients")
+      .text("ungefähr " + (nClients - nLegacyNodes) + " Clients")
 
     data = wilder_scheiß(data)
 


### PR DESCRIPTION
The backend now tracks gluon/alfred nodes. Those nodes have no longer
an indistinguishable ghost node. Hence we have to adjust the client
counting.
