### PR TITLE
list: move footer creation out of update()

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -1,5 +1,6 @@
 function nodetable(table, fn) {
   var thead, tbody, tfoot
+  var routersum, clientsum, lastupdate
 
   function prepare() {
     thead = table.append("thead")
@@ -17,23 +18,9 @@ function nodetable(table, fn) {
 
     var foot = tfoot.append("tr")
     foot.append("td").text("Summe")
-    foot.append("td").append("span").attr("id", "routersum")
-    foot.append("td").append("span").attr("id", "clientsum")
-    foot.append("td")
-      .attr("colspan", 4).style("text-align", "right").text("Zuletzt aktualisiert: ")
-      .append("span").attr("id", "lastupdate")
-  }
-
-  function update_routersum(online, total) {
-    tfoot.select("#routersum").text(online + " / " + total)
-  }
-
-  function update_clientsum(total) {
-    tfoot.select("#clientsum").text(total)
-  }
-
-  function update_lastupdate(date) {
-    tfoot.select("#lastupdate").text(date.toLocaleString())
+    routersum = foot.append("td")
+    clientsum = foot.append("td")
+    lastupdate = foot.append("td").attr("colspan", 4).style("text-align", "right").text("Zuletzt aktualisiert: ").append("span")
   }
 
   function sum(arr, attr) {
@@ -56,9 +43,9 @@ function nodetable(table, fn) {
 
     doc.exit().remove()
 
-    update_routersum(non_clients.reduce(function(old, node) { return old + node.flags.online }, 0), non_clients.length)
-    update_clientsum(non_clients.reduce(function(old, node) { return old + node.clients.length }, 0))
-    update_lastupdate(new Date(data.meta.timestamp + 'Z'))
+    routersum.text(non_clients.reduce(function(old, node) { return old + node.flags.online }, 0) + " / " + non_clients.length)
+    clientsum.text(non_clients.reduce(function(old, node) { return old + node.clients.length }, 0))
+    lastupdate.text(new Date(data.meta.timestamp + 'Z').toLocaleString())
 
     $("#list").tablesorter({sortList: [[0,0]]})
   }


### PR DESCRIPTION
Made the update() method callable more than once and moved setting the footer values to separate methods (which I would like to use when filtering the table by router name).
