### PR TITLE
Fixed form elements on displays with zoomed fonts.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,6 +4,11 @@ body {
   font-family: sans serif, sans, arial;
 }
 
+input, select, button {
+  font-family: inherit;
+  font-size: 100%;
+}
+
 header h1, ul {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
If `org.gnome.desktop.interface text-scaling-factor` is set to 2.0 most form elements had extremely large font.
