### PR TITLE
Make map and chart working with Internet Explorer <= 11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "leaflet": "~0.7.3",
     "bacon": "~0.7.22",
     "jquery.tablesorter": "~2.17.7",
-    "requirejs": "~2.1.15"
+    "requirejs": "~2.1.15",
+    "es6-promise": "~2.0.1"
   }
 }

--- a/css/graph.css
+++ b/css/graph.css
@@ -218,6 +218,7 @@ footer a {
 
 #chart {
   background-image: url(gplaypattern.png);
+  overflow: hidden;
 }
 
 .node, .link {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,10 +1,15 @@
 define("loader", [
   "lib/d3",
-  "lib/Bacon"
+  "lib/Bacon",
+  "lib/promise"
 ], function (d3, Bacon) {
   "use strict"
 
   var Promise = window.Promise
+  // Internet explorer lacks promises support
+  if (typeof Promise === "undefined")
+    Promise = require("lib/promise").Promise
+
   function get(url) {
     return new Promise(function(resolve, reject) {
       var req = new XMLHttpRequest()

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -46,7 +46,8 @@ module.exports = function(grunt) {
           "bower_components/d3/d3.js",
           "bower_components/leaflet/dist/leaflet-src.js",
           "bower_components/jquery/dist/jquery.js",
-          "bower_components/jquery.tablesorter/js/jquery.tablesorter.js"
+          "bower_components/jquery.tablesorter/js/jquery.tablesorter.js",
+          "bower_components/es6-promise/promise.js"
         ],
         expand: true,
         flatten: true,


### PR DESCRIPTION
The issue is caused by the lack of promises support in Internet Explorer <= 11.
This patch implements a fallback using the following library, if there's no promises support available:
https://github.com/jakearchibald/es6-promise