### PR TITLE
Move node info popup code to own module

### DIFF
--- a/config.js
+++ b/config.js
@@ -25,6 +25,7 @@ define("config", function () {
     },
 
     map: {
+      showNodeInfo: true,
       layer: {
         url: "http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg",
         config: {

--- a/config.js
+++ b/config.js
@@ -25,7 +25,7 @@ define("config", function () {
     },
 
     map: {
-      showNodeInfo: true,
+      showNodeInfo: false,
       layer: {
         url: "http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg",
         config: {

--- a/css/graph.css
+++ b/css/graph.css
@@ -58,29 +58,6 @@ header, footer {
   stroke-width: 5px !important;
 }
 
-#nodeinfo {
-  position: absolute;
-  background: #fff;
-  border: 1px solid #ddd;
-  padding: 0.5em;
-  font-family: arial, helvatica;
-}
-
-#nodeinfo {
-  top: 10px;
-  left: 10px;
-  z-index: 10;
-}
-
-#nodeinfo a {
-  color: #444;
-}
-
-#nodeinfo button.close {
-  cursor: pointer;
-  float: right;
-}
-
 #controlpanel {
   font-size: 10pt;
   display: inline-block;
@@ -93,24 +70,6 @@ header, footer {
 
 #controlpanel p {
   margin: 0 1em;
-}
-
-#nodeinfo h1, #nodeinfo p {
-  color: #555;
-}
-
-#nodeinfo h1 {
-  font-size: 10pt;
-  margin: 0 0 0.5em;
-}
-
-#nodeinfo h2 {
-  font-size: 9pt;
-}
-
-#nodeinfo p {
-  font-size: 10pt;
-  margin: 0;
 }
 
 .btn {

--- a/css/style.css
+++ b/css/style.css
@@ -88,3 +88,45 @@ header h1 a {
 #sidebar .toggler:active {
   background-color: #FFDD20;
 }
+
+#nodeinfo {
+  font-size: 10pt;
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ddd;
+  padding: 0.5em;
+  font-family: arial, helvatica;
+  top: 10px;
+  left: 10px;
+  z-index: 1200;
+  max-height: 95%;
+  overflow: scroll;
+}
+
+#nodeinfo a {
+  color: #444;
+}
+
+#nodeinfo button.close {
+  cursor: pointer;
+  float: right;
+  font-size: 12pt;
+}
+
+#nodeinfo h1, #nodeinfo p {
+  color: #555;
+}
+
+#nodeinfo h1 {
+  font-size: 10pt;
+  margin: 0 0 0.5em;
+}
+
+#nodeinfo h2 {
+  font-size: 9pt;
+}
+
+#nodeinfo p {
+  font-size: 10pt;
+  margin: 0;
+}

--- a/lib/geomap.js
+++ b/lib/geomap.js
@@ -3,8 +3,9 @@ define("geomap", [
   "lib/d3",
   "links",
   "loader",
-  "config"
-], function (L, d3, linkColor, loadNodes, ffmapConfig) {
+  "config",
+  "nodeinfo"
+], function (L, d3, linkColor, loadNodes, ffmapConfig, nodeInfo) {
   "use strict"
 
   var map
@@ -119,7 +120,12 @@ define("geomap", [
             .attr("fill", function (d) {
               return d.flags.online ? (!d.firmware ? "rgba(255, 55, 55, 1.0)" : "rgba(0, 255, 0, 0.8)") : "rgba(128, 128, 128, 0.2)"
             })
-            .on("click", function(n) { window.location.href = "graph.html#" + n.id })
+            .on("click", function(n) {
+              if (ffmapConfig.map && ffmapConfig.map.showNodeInfo)
+                nodeInfo.show("#map",n)
+              else
+                window.location.href = "graph.html#" + n.id
+            })
             .append("title").text( function (n) { return n.name ? n.name : n.id })
 
     linksSvg.enter().append("line")

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -3,8 +3,9 @@ define("graph", [
   "lib/d3",
   "config",
   "links",
-  "loader"
-], function (Bacon, d3, ffmapConfig, linkColor, loadNodes) {
+  "loader",
+  "nodeinfo"
+], function (Bacon, d3, ffmapConfig, linkColor, loadNodes, nodeInfo) {
   "use strict"
 
   window.onresize = resize
@@ -148,79 +149,7 @@ define("graph", [
   function gotoNode(d) {
     if (d3.event.defaultPrevented)
       return
-
-    showNodeInfo(d)
-  }
-
-  function showNodeInfo(d) {
-    d3.selectAll("#nodeinfo").remove()
-
-    var nodeinfo = d3.select("#chart")
-                 .append("div")
-                 .attr("id", "nodeinfo")
-
-    nodeinfo.append("button")
-            .attr("class", "close")
-            .text("x")
-            .on("click", function() {
-               nodeinfo.remove()
-            })
-
-    nodeinfo.append("h1")
-            .text(d.name + " / " + d.id)
-
-    if (!ffmapConfig.graph || !ffmapConfig.graph.type || ffmapConfig.graph.type !== "none") {
-      nodeinfo.append("h2").text("Stats")
-
-      if (!ffmapConfig.graph || !ffmapConfig.graph.type || ffmapConfig.graph.type === "rrd") {
-        var imglink = "nodes/" + d.id.replace(/:/g, "") + ".png"
-
-        nodeinfo.append("a")
-                .attr("target", "_blank")
-                .attr("href", imglink)
-                .append("img")
-                .attr("src", imglink)
-                .attr("width", "300")
-
-      }
-      /*else if (ffmapConfig.graph.type === "graphite") {
-       //TODO: Add d3 chart
-      }*/
-
-    }
-
-    nodeinfo.append("h2").text("VPN-Links")
-
-    nodeinfo.append("ul")
-            .selectAll("li")
-            .data(d.vpns)
-            .enter().append("li")
-                    .append("a")
-                    .on("click", gotoNode)
-                    .attr("href", "#")
-                    .text(function(d) {
-                      return d.name
-                    })
-
-    nodeinfo.append("p")
-            .append("label")
-            .text("Clients: " + d.clientcount)
-
-    nodeinfo.append("p")
-            .append("label")
-            .text("WLAN Verbindungen: " + d.wifilinks.length)
-
-    if (d.geo) {
-      nodeinfo.append("h2").text("Geodaten")
-
-      nodeinfo.append("p")
-              .append("a")
-              // Open the geomap in another window as we'd lose state of this
-              // graph when the user navigates back.
-              .attr("target","_blank")
-              .attr("href","geomap.html#lat=" + d.geo[0] + "&lon=" + d.geo[1])
-              .text(d.geo[0] + ", " + d.geo[1])
-    }
+    nodeInfo.show("#chart",d)
   }
 
   function toggleButton(button) {

--- a/lib/nodeinfo.js
+++ b/lib/nodeinfo.js
@@ -1,0 +1,89 @@
+define("nodeinfo", [
+  "lib/d3",
+  "config"
+], function (d3, ffmapConfig) {
+  "use strict"
+
+  var nodeInfo = {
+
+    show: function(container, d) {
+      var self = this
+      d3.selectAll("#nodeinfo").remove()
+
+      var nodeinfo = d3.select(container)
+        .append("div")
+        .attr("id", "nodeinfo")
+
+      nodeinfo.append("button")
+        .attr("class", "close")
+        .text("x")
+        .on("click", function() {
+          nodeinfo.remove()
+        })
+
+      nodeinfo.append("h1")
+        .text(d.name + " / " + d.id)
+
+      if (!ffmapConfig.graph || !ffmapConfig.graph.type || ffmapConfig.graph.type !== "none") {
+        nodeinfo.append("h2").text("Stats")
+
+        if (!ffmapConfig.graph || !ffmapConfig.graph.type || ffmapConfig.graph.type === "rrd") {
+          var imglink = "nodes/" + d.id.replace(/:/g, "") + ".png"
+
+          nodeinfo.append("a")
+            .attr("target", "_blank")
+            .attr("href", imglink)
+            .append("img")
+            .attr("src", imglink)
+            .attr("width", "300")
+
+        }
+        /*else if (ffmapConfig.graph.type === "graphite") {
+         //TODO: Add d3 chart
+         }*/
+
+      }
+
+      nodeinfo.append("h2").text("VPN-Links")
+
+      nodeinfo.append("ul")
+        .selectAll("li")
+        .data(d.vpns)
+        .enter().append("li")
+        .append("a")
+        .on("click", function(d) {
+          if (d3.event.defaultPrevented)
+            return
+          self.show(container,d)
+        })
+        .attr("href", "#")
+        .text(function(d) {
+          return d.name
+        })
+
+      nodeinfo.append("p")
+        .append("label")
+        .text("Clients: " + d.clientcount)
+
+      nodeinfo.append("p")
+        .append("label")
+        .text("WLAN Verbindungen: " + d.wifilinks.length)
+
+      if (d.geo) {
+        nodeinfo.append("h2").text("Geodaten")
+
+        nodeinfo.append("p")
+          .append("a")
+          // Open the geomap in another window as we'd lose state of this
+          // graph when the user navigates back.
+          .attr("target","_blank")
+          .attr("href","geomap.html#lat=" + d.geo[0] + "&lon=" + d.geo[1])
+          .text(d.geo[0] + ", " + d.geo[1])
+      }
+    }
+
+  }
+
+  return nodeInfo
+
+})


### PR DESCRIPTION
In favour of clean code and modularity, I moved the code responsible for the node's info popup to its own require.js module.
Furthermore it gives us the possibility to use the popup on the map, too.