### PR TITLE
Allow configuration of initial map viewport

### DIFF
--- a/config.js
+++ b/config.js
@@ -103,6 +103,13 @@ define("config", [
 
     map: {
       showNodeInfo: false,
+      /*
+      init: {
+        lat: 50.77621,
+        lon: 6.08385,
+        zoom: 12
+      },
+      */
       layer: {
         url: "http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg",
         config: {

--- a/lib/geomap.js
+++ b/lib/geomap.js
@@ -109,6 +109,8 @@ define("geomap", [
         zoom = params.zoom
       map.setView(L.latLng(params.lat, params.lon), zoom)
     }
+    else if (ffmapConfig.map.init)
+      map.setView(L.latLng(ffmapConfig.map.init.lat, ffmapConfig.map.init.lon), ffmapConfig.map.init.zoom)
     else
       map.fitBounds(bounds)
 


### PR DESCRIPTION
To avoid problems with misconfigured nodes (we just had a node at the North Pole ;-)), we would like to force the initial map viewport based on configuration options.
